### PR TITLE
Factor out controllers

### DIFF
--- a/apps/server/src/banner-assignment/controller.spec.ts
+++ b/apps/server/src/banner-assignment/controller.spec.ts
@@ -1,0 +1,35 @@
+import { bannerRequestFactory, bannerTestFactory } from '@sdc-libs/factories';
+import { BannerTest } from '@sdc-libs/types';
+import { getCreate } from './controller';
+
+describe('create', () => {
+  it('returns a banner if there is one that matches the targeting', async () => {
+    const test = bannerTestFactory.build({
+      targeting: { edition: 'UK' },
+    });
+    const request = bannerRequestFactory.build({ edition: 'UK' });
+
+    const create = getCreate(getBannerTests(test));
+
+    const result = await create(request);
+
+    expect(result.assigned).toBeTruthy();
+  });
+
+  it("doesn't return a banner if there isn't one that matches the targeting", async () => {
+    const test = bannerTestFactory.build({
+      targeting: { edition: 'UK' },
+    });
+    const request = bannerRequestFactory.build({ edition: 'US' });
+
+    const create = getCreate(getBannerTests(test));
+
+    const result = await create(request);
+
+    expect(result.assigned).toBeFalsy();
+  });
+});
+
+// ---- Utils ---- //
+
+const getBannerTests = (test: BannerTest) => () => Promise.resolve([test]);

--- a/apps/server/src/banner-assignment/controller.ts
+++ b/apps/server/src/banner-assignment/controller.ts
@@ -1,0 +1,36 @@
+import { BannerRequest, BannerTest, Copy } from '@sdc-libs/types';
+import { assigned, Assignment, notAssigned } from '../assignment';
+import { selectTest } from './selection';
+
+type GetBannerTests = () => Promise<BannerTest[]>;
+
+interface BannerAssignment {
+  meta: {
+    testName: string;
+  };
+  props: {
+    copy: Copy;
+  };
+}
+
+type CreateBannerAssignmentResponse = Assignment<BannerAssignment>;
+
+export const getCreate =
+  (getBannerTests: GetBannerTests) =>
+  async (req: BannerRequest): Promise<CreateBannerAssignmentResponse> => {
+    const tests = await getBannerTests();
+    const test = selectTest(tests, req);
+
+    if (!test) {
+      return notAssigned();
+    }
+
+    return assigned({
+      meta: {
+        testName: test.name,
+      },
+      props: {
+        copy: test.copy,
+      },
+    });
+  };

--- a/apps/server/src/banner-assignment/router.spec.ts
+++ b/apps/server/src/banner-assignment/router.spec.ts
@@ -1,68 +1,27 @@
-import { bannerRequestFactory, bannerTestFactory } from '@sdc-libs/factories';
-import { BannerTest } from '@sdc-libs/types';
+import { bannerRequestFactory } from '@sdc-libs/factories';
 import { getRouter } from './router';
 import * as express from 'express';
 import supertest = require('supertest');
 
-describe('/banner', () => {
-  it('returns a banner if there is one that matches the targeting', async () => {
-    const st = getSuperTest(
-      getRouter({
-        getBannerTests: getBannerTests(
-          bannerTestFactory.build({
-            name: 'EXAMPLE_TEST',
-            targeting: { edition: 'UK' },
-          })
-        ),
-      })
-    );
-    const bannerRequest = bannerRequestFactory.build({ edition: 'UK' });
+describe('router', () => {
+  const router = getRouter({ getBannerTests: () => Promise.resolve([]) });
+  const app = express();
+  app.use('/', router);
+  const request = supertest(app);
 
-    const response = await st.post('/banner').send(bannerRequest);
+  it('returns a 200 for a valid request', async () => {
+    const bannerRequest = bannerRequestFactory.build();
+
+    const response = await request.post('/').send(bannerRequest);
 
     expect(response.statusCode).toBe(200);
-    expect(response.body.assigned).toBeTruthy();
-  });
-
-  it("doesn't return a banner if there isn't one that matches the targeting", async () => {
-    const st = getSuperTest(
-      getRouter({
-        getBannerTests: getBannerTests(
-          bannerTestFactory.build({
-            name: 'EXAMPLE_TEST',
-            targeting: { edition: 'UK' },
-          })
-        ),
-      })
-    );
-    const bannerRequest = bannerRequestFactory.build({ edition: 'AU' });
-
-    const response = await st.post('/banner').send(bannerRequest);
-
-    expect(response.statusCode).toBe(200);
-    expect(response.body.assigned).toBeFalsy();
   });
 
   it('returns a 400 for an invalid payload', async () => {
-    const st = getSuperTest(
-      getRouter({
-        getBannerTests: getBannerTests(bannerTestFactory.build()),
-      })
-    );
     const bannerRequest = { foo: 'bar' };
 
-    const response = await st.post('/banner').send(bannerRequest);
+    const response = await request.post('/').send(bannerRequest);
 
     expect(response.statusCode).toBe(400);
   });
 });
-
-// ---- Utils ---- //
-
-const getSuperTest = (router: express.Router) => {
-  const app = express();
-  app.use('/banner', router);
-  return supertest(app);
-};
-
-const getBannerTests = (test: BannerTest) => () => Promise.resolve([test]);

--- a/apps/server/src/banner-assignment/router.ts
+++ b/apps/server/src/banner-assignment/router.ts
@@ -1,9 +1,9 @@
-import { BannerRequest, BannerTest } from '@sdc-libs/types';
+import { BannerTest } from '@sdc-libs/types';
 import { bannerRequestSchema } from '@sdc-libs/validation';
 import * as express from 'express';
-import { assigned, notAssigned } from '../assignment';
+import { Request, Response } from 'express';
 import { validate } from '../validation';
-import { selectTest } from './selection';
+import { getCreate } from './controller';
 
 interface RouterOptions {
   getBannerTests: () => Promise<BannerTest[]>;
@@ -16,28 +16,17 @@ export function getRouter({ getBannerTests }: RouterOptions) {
     '/',
     express.json(),
     validate(bannerRequestSchema),
-    async (req, res) => {
-      const body = req.body as BannerRequest;
-
-      const tests = await getBannerTests();
-      const test = selectTest(tests, body);
-
-      if (!test) {
-        return res.json(notAssigned());
-      }
-
-      res.json(
-        assigned({
-          meta: {
-            testName: test.name,
-          },
-          props: {
-            copy: test.copy,
-          },
-        })
-      );
-    }
+    makeJsonEndpoint(getCreate(getBannerTests))
   );
 
   return router;
 }
+
+// ---- Utils ---- //
+
+const makeJsonEndpoint =
+  <Req, Res>(controllerAction: (req: Req) => Promise<Res>) =>
+  async (req: Request, res: Response) => {
+    const json = await controllerAction(req.body as Req);
+    res.json(json);
+  };

--- a/apps/server/src/banner-assignment/router.ts
+++ b/apps/server/src/banner-assignment/router.ts
@@ -1,7 +1,7 @@
 import { BannerTest } from '@sdc-libs/types';
 import { bannerRequestSchema } from '@sdc-libs/validation';
 import * as express from 'express';
-import { Request, Response } from 'express';
+import { makeSimpleJsonEndpoint } from '../router';
 import { validate } from '../validation';
 import { getCreate } from './controller';
 
@@ -16,17 +16,8 @@ export function getRouter({ getBannerTests }: RouterOptions) {
     '/',
     express.json(),
     validate(bannerRequestSchema),
-    makeJsonEndpoint(getCreate(getBannerTests))
+    makeSimpleJsonEndpoint(getCreate(getBannerTests))
   );
 
   return router;
 }
-
-// ---- Utils ---- //
-
-const makeJsonEndpoint =
-  <Req, Res>(controllerAction: (req: Req) => Promise<Res>) =>
-  async (req: Request, res: Response) => {
-    const json = await controllerAction(req.body as Req);
-    res.json(json);
-  };

--- a/apps/server/src/header-assignment/controller.spec.ts
+++ b/apps/server/src/header-assignment/controller.spec.ts
@@ -1,0 +1,35 @@
+import { headerRequestFactory, headerTestFactory } from '@sdc-libs/factories';
+import { HeaderTest } from '@sdc-libs/types';
+import { getCreate } from './controller';
+
+describe('create', () => {
+  it('returns a header if there is one that matches the targeting', async () => {
+    const test = headerTestFactory.build({
+      targeting: { edition: 'UK' },
+    });
+    const request = headerRequestFactory.build({ edition: 'UK' });
+
+    const create = getCreate(getHeaderTests(test));
+
+    const result = await create(request);
+
+    expect(result.assigned).toBeTruthy();
+  });
+
+  it("doesn't return a banner if there isn't one that matches the targeting", async () => {
+    const test = headerTestFactory.build({
+      targeting: { edition: 'UK' },
+    });
+    const request = headerRequestFactory.build({ edition: 'US' });
+
+    const create = getCreate(getHeaderTests(test));
+
+    const result = await create(request);
+
+    expect(result.assigned).toBeFalsy();
+  });
+});
+
+// ---- Utils ---- //
+
+const getHeaderTests = (test: HeaderTest) => () => Promise.resolve([test]);

--- a/apps/server/src/header-assignment/controller.ts
+++ b/apps/server/src/header-assignment/controller.ts
@@ -1,0 +1,36 @@
+import { HeaderRequest, HeaderTest } from '@sdc-libs/types';
+import { assigned, Assignment, notAssigned } from '../assignment';
+import { selectTest } from './selection';
+
+type GetHeaderTests = () => Promise<HeaderTest[]>;
+
+interface HeaderAssignment {
+  meta: {
+    testName: string;
+  };
+  props: {
+    copy: string;
+  };
+}
+
+type CreateHeaderAssignmentResponse = Assignment<HeaderAssignment>;
+
+export const getCreate =
+  (getBannerTests: GetHeaderTests) =>
+  async (req: HeaderRequest): Promise<CreateHeaderAssignmentResponse> => {
+    const tests = await getBannerTests();
+    const test = selectTest(tests, req);
+
+    if (!test) {
+      return notAssigned();
+    }
+
+    return assigned({
+      meta: {
+        testName: test.name,
+      },
+      props: {
+        copy: test.copy,
+      },
+    });
+  };

--- a/apps/server/src/header-assignment/router.spec.ts
+++ b/apps/server/src/header-assignment/router.spec.ts
@@ -1,67 +1,27 @@
-import { headerRequestFactory, headerTestFactory } from '@sdc-libs/factories';
+import { headerRequestFactory } from '@sdc-libs/factories';
 import { getRouter } from './router';
 import * as express from 'express';
 import supertest = require('supertest');
-import { HeaderTest } from '@sdc-libs/types';
 
 describe('/header', () => {
-  it('returns a header if there is one that matches the targeting', async () => {
-    const st = getSuperTest(
-      getRouter({
-        getHeaderTests: getHeaderTests(
-          headerTestFactory.build({
-            name: 'EXAMPLE_TEST',
-            targeting: { edition: 'UK' },
-          })
-        ),
-      })
-    );
-    const headerRequest = headerRequestFactory.build({ edition: 'UK' });
+  const router = getRouter({ getHeaderTests: () => Promise.resolve([]) });
+  const app = express();
+  app.use('/', router);
+  const request = supertest(app);
 
-    const response = await st.post('/header').send(headerRequest);
+  it('returns a 200 for a valid request', async () => {
+    const headerRequest = headerRequestFactory.build();
+
+    const response = await request.post('/').send(headerRequest);
 
     expect(response.statusCode).toBe(200);
-    expect(response.body.assigned).toBeTruthy();
-  });
-
-  it("doesn't return a header if there isn't one that matches the targeting", async () => {
-    const st = getSuperTest(
-      getRouter({
-        getHeaderTests: getHeaderTests(
-          headerTestFactory.build({
-            targeting: { edition: 'AU' },
-          })
-        ),
-      })
-    );
-    const headerRequest = headerRequestFactory.build({ edition: 'UK' });
-
-    const response = await st.post('/header').send(headerRequest);
-
-    expect(response.statusCode).toBe(200);
-    expect(response.body.assigned).toBeFalsy();
   });
 
   it('returns a 400 for an invalid payload', async () => {
-    const st = getSuperTest(
-      getRouter({
-        getHeaderTests: getHeaderTests(headerTestFactory.build()),
-      })
-    );
     const headerRequest = { foo: 'bar' };
 
-    const response = await st.post('/header').send(headerRequest);
+    const response = await request.post('/').send(headerRequest);
 
     expect(response.statusCode).toBe(400);
   });
 });
-
-// ---- Utils ---- //
-
-const getSuperTest = (router: express.Router) => {
-  const app = express();
-  app.use('/header', router);
-  return supertest(app);
-};
-
-const getHeaderTests = (test: HeaderTest) => () => Promise.resolve([test]);

--- a/apps/server/src/header-assignment/router.ts
+++ b/apps/server/src/header-assignment/router.ts
@@ -1,9 +1,9 @@
-import { HeaderRequest, HeaderTest } from '@sdc-libs/types';
+import { HeaderTest } from '@sdc-libs/types';
 import { headerRequestSchema } from '@sdc-libs/validation';
 import * as express from 'express';
-import { assigned, notAssigned } from '../assignment';
+import { makeSimpleJsonEndpoint } from '../router';
 import { validate } from '../validation';
-import { selectTest } from './selection';
+import { getCreate } from './controller';
 
 interface RouterOptions {
   getHeaderTests: () => Promise<HeaderTest[]>;
@@ -16,27 +16,7 @@ export function getRouter({ getHeaderTests }: RouterOptions) {
     '/',
     express.json(),
     validate(headerRequestSchema),
-    async (req, res) => {
-      const body = req.body as HeaderRequest;
-
-      const tests = await getHeaderTests();
-      const test = selectTest(tests, body);
-
-      if (!test) {
-        return res.json(notAssigned());
-      }
-
-      res.json(
-        assigned({
-          meta: {
-            testName: test.name,
-          },
-          props: {
-            copy: test.copy,
-          },
-        })
-      );
-    }
+    makeSimpleJsonEndpoint(getCreate(getHeaderTests))
   );
 
   return router;

--- a/apps/server/src/router.ts
+++ b/apps/server/src/router.ts
@@ -1,0 +1,19 @@
+import { Request, Response } from 'express';
+
+type ControllerAction<Req, Res> = (req: Req) => Promise<Res>;
+
+type Extract<Req> = (req: Request) => Req;
+
+export const makeJsonEndpoint =
+  <Req, Res>(
+    controllerAction: ControllerAction<Req, Res>,
+    extract: Extract<Req>
+  ) =>
+  async (req: Request, res: Response) => {
+    const json = await controllerAction(extract(req));
+    res.json(json);
+  };
+
+export const makeSimpleJsonEndpoint = <Req, Res>(
+  controllerAction: ControllerAction<Req, Res>
+) => makeJsonEndpoint(controllerAction, (req) => req.body);


### PR DESCRIPTION
I've introduced the concept of a `Controller` and factored that out from the `Router`s. A `controller` function is just a pure function mapping from some input to some output. The `router` is then responsible for wiring this up as an `express` endpoint. 

This simplified to router tests which now just check for valid status codes & moved the more complex tests into the controller tests. These are quicker to test now as it doesn't involve spinning up a new app with `supertest`.